### PR TITLE
refactor: add context api

### DIFF
--- a/v2/interface.go
+++ b/v2/interface.go
@@ -1,6 +1,8 @@
 package v2
 
 import (
+	"context"
+
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 
 	"github.com/honestbank/kp/v2/internal/middleware"
@@ -13,5 +15,5 @@ type KafkaProcessor[MessageType any] interface {
 	WithDeadletter(deadLetterTopic string) (KafkaProcessor[MessageType], error)
 	WithDeadletterOrPanic(deadletterTopic string) KafkaProcessor[MessageType]
 	Stop()
-	Run(processor func(message MessageType) error) error
+	Run(processor func(ctx context.Context, message MessageType) error) error
 }

--- a/v2/internal/middleware/middleware.go
+++ b/v2/internal/middleware/middleware.go
@@ -1,26 +1,28 @@
 package middleware
 
+import "context"
+
 type finalMiddleware[IN, OUT any] struct {
-	processor func(item IN) OUT
+	processor func(ctx context.Context, item IN) OUT
 }
 
-func (m finalMiddleware[IN, OUT]) Process(item IN, next func(item IN) OUT) OUT {
-	return m.processor(item)
+func (m finalMiddleware[IN, OUT]) Process(ctx context.Context, item IN, next func(ctx context.Context, item IN) OUT) OUT {
+	return m.processor(ctx, item)
 }
 
-func FinalMiddleware[IN, OUT any](fn func(item IN) OUT) Middleware[IN, OUT] {
+func FinalMiddleware[IN, OUT any](fn func(ctx context.Context, item IN) OUT) Middleware[IN, OUT] {
 	return finalMiddleware[IN, OUT]{
 		processor: fn,
 	}
 }
 
 type Middleware[IN any, OUT any] interface {
-	Process(item IN, next func(item IN) OUT) OUT
+	Process(ctx context.Context, item IN, next func(ctx context.Context, item IN) OUT) OUT
 }
 
 type Processor[IN any, OUT any] interface {
 	AddMiddleware(middleware Middleware[IN, OUT])
-	Process(input IN) OUT
+	Process(ctx context.Context, input IN) OUT
 }
 
 type stack[IN any, OUT any] struct {
@@ -31,15 +33,15 @@ func (r *stack[IN, OUT]) AddMiddleware(mw Middleware[IN, OUT]) {
 	r.middlewares = append(r.middlewares, mw)
 }
 
-func (r *stack[IN, OUT]) Process(options IN) OUT {
-	var next func(item IN) OUT = nil
+func (r *stack[IN, OUT]) Process(ctx context.Context, options IN) OUT {
+	var next func(c context.Context, item IN) OUT = nil
 	middlewares := append(r.middlewares)
-	next = func(item IN) OUT {
+	next = func(c context.Context, item IN) OUT {
 		nextMw := middlewares[0]
 		middlewares = middlewares[1:]
-		return nextMw.Process(item, next)
+		return nextMw.Process(c, item, next)
 	}
-	return next(options)
+	return next(ctx, options)
 }
 
 func New[IN, OUT any]() Processor[IN, OUT] {

--- a/v2/internal/middleware/middleware_test.go
+++ b/v2/internal/middleware/middleware_test.go
@@ -1,6 +1,7 @@
 package middleware_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,22 +12,32 @@ import (
 type customMw struct {
 }
 
-func (r customMw) Process(item int, next func(item int) int) int {
-	return next(item + 5)
+func (r customMw) Process(ctx context.Context, item int, next func(ctx context.Context, item int) int) int {
+	return next(context.WithValue(ctx, "key", "some-value"), item+5)
 }
 
 func TestNew(t *testing.T) {
 	t.Run("simple", func(t *testing.T) {
 		pipeline := middleware.New[int, int]()
-		pipeline.AddMiddleware(middleware.FinalMiddleware[int, int](func(item int) int { return item * item }))
-		assert.Equal(t, 1, pipeline.Process(1))
-		assert.Equal(t, 25, pipeline.Process(5))
+		pipeline.AddMiddleware(middleware.FinalMiddleware[int, int](func(ctx context.Context, item int) int { return item * item }))
+		assert.Equal(t, 1, pipeline.Process(context.Background(), 1))
+		assert.Equal(t, 25, pipeline.Process(context.Background(), 5))
 	})
 	t.Run("with middleware", func(t *testing.T) {
 		pipeline := middleware.New[int, int]()
 		pipeline.AddMiddleware(customMw{})
-		pipeline.AddMiddleware(middleware.FinalMiddleware[int, int](func(item int) int { return item * item }))
-		assert.Equal(t, 36, pipeline.Process(1))
-		assert.Equal(t, 100, pipeline.Process(5))
+		pipeline.AddMiddleware(middleware.FinalMiddleware[int, int](func(ctx context.Context, item int) int { return item * item }))
+		assert.Equal(t, 36, pipeline.Process(context.Background(), 1))
+		assert.Equal(t, 100, pipeline.Process(context.Background(), 5))
+	})
+
+	t.Run("with context values", func(t *testing.T) {
+		pipeline := middleware.New[int, int]()
+		pipeline.AddMiddleware(customMw{})
+		pipeline.AddMiddleware(middleware.FinalMiddleware[int, int](func(ctx context.Context, item int) int {
+			assert.Equal(t, "some-value", ctx.Value("key"))
+			return item
+		}))
+		pipeline.Process(context.Background(), 20)
 	})
 }

--- a/v2/kp_example_test.go
+++ b/v2/kp_example_test.go
@@ -29,7 +29,7 @@ func ExampleNew() {
 	}()
 	processor.WithRetryOrPanic("user-logged-in-rewards-processor-retry", 3).
 		WithDeadletterOrPanic("user-logged-in-rewards-processor-dlt").
-		Run(func(ev UserLoggedInEvent) error {
+		Run(func(ctx context.Context, ev UserLoggedInEvent) error {
 			fmt.Printf("%s|", ev.UserID)
 			return errors.New("some error")
 		})

--- a/v2/kp_test.go
+++ b/v2/kp_test.go
@@ -23,9 +23,9 @@ type MyType struct {
 type MyMw struct {
 }
 
-func (m MyMw) Process(item *kafka.Message, next func(item *kafka.Message) error) error {
+func (m MyMw) Process(ctx context.Context, item *kafka.Message, next func(ctx context.Context, item *kafka.Message) error) error {
 	fmt.Println("Before:")
-	result := next(item)
+	result := next(ctx, item)
 	fmt.Printf("After with return value: %v\n", result)
 
 	return result
@@ -55,7 +55,7 @@ func TestKP(t *testing.T) {
 	err = kp.WithRetryOrPanic("kp-topic-retry", retryCount).
 		AddMiddleware(MyMw{}).
 		WithDeadletterOrPanic("kp-topic-dlt").
-		Run(func(message MyType) error {
+		Run(func(ctx context.Context, message MyType) error {
 			time.Sleep(time.Millisecond * 200)
 			fmt.Printf("%v\n", message)
 			messageProcessCount++


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.
-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to
  the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* This adds context API so that we can pass values around.
* This also now makes it such that only the core functionality along with retries, dead lettering, and middlewares are first-class citizens of KP.
* things like backoff, tracing, measurements, logs, etc are second-class citizens and will be done through middleware and the KP won't expose API directly.
* context will also allow us to get things like retry count, tracing etc in our worker.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/kp/20)
<!-- Reviewable:end -->
