### PR TITLE
refactor: change produce signature, add header util

### DIFF
--- a/v2/internal/consumer/consumer_test.go
+++ b/v2/internal/consumer/consumer_test.go
@@ -3,6 +3,7 @@
 package consumer_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -22,7 +23,7 @@ func TestNew(t *testing.T) {
 	t.Run("can read from kafka", func(t *testing.T) {
 		c, err := consumer.New([]string{"consumer-integration-topic-1"}, "consumer-group-1")
 		assert.NoError(t, err)
-		p1, err := producer.New[MyMsg, string]("consumer-integration-topic-1")
+		p1, err := producer.New[MyMsg]("consumer-integration-topic-1")
 		assert.NoError(t, err)
 		shouldContinue, numberOfMessage := true, 0
 		go func() {
@@ -35,11 +36,11 @@ func TestNew(t *testing.T) {
 				numberOfMessage++
 			}
 		}()
-		err = p1.Produce(producer.KafkaMessage[MyMsg, string]{Body: MyMsg{Time: time.Now().Format(time.RFC3339Nano)}})
+		err = p1.Produce(context.Background(), MyMsg{Time: time.Now().Format(time.RFC3339Nano)})
 		assert.NoError(t, err)
-		err = p1.Produce(producer.KafkaMessage[MyMsg, string]{Body: MyMsg{Time: time.Now().Format(time.RFC3339Nano)}})
+		err = p1.Produce(context.Background(), MyMsg{Time: time.Now().Format(time.RFC3339Nano)})
 		assert.NoError(t, err)
-		err = p1.Produce(producer.KafkaMessage[MyMsg, string]{Body: MyMsg{Time: time.Now().Format(time.RFC3339Nano)}})
+		err = p1.Produce(context.Background(), MyMsg{Time: time.Now().Format(time.RFC3339Nano)})
 		assert.NoError(t, err)
 		time.Sleep(time.Millisecond * 500)
 		p1.Flush()
@@ -51,9 +52,9 @@ func TestNew(t *testing.T) {
 	t.Run("can read from multiple topics", func(t *testing.T) {
 		c, err := consumer.New([]string{"consumer-integration-topic-2", "consumer-integration-topic-3"}, "consumer-group-2")
 		assert.NoError(t, err)
-		p1, err := producer.New[MyMsg, string]("consumer-integration-topic-2")
+		p1, err := producer.New[MyMsg]("consumer-integration-topic-2")
 		assert.NoError(t, err)
-		p2, err := producer.New[MyMsg, string]("consumer-integration-topic-3")
+		p2, err := producer.New[MyMsg]("consumer-integration-topic-3")
 		assert.NoError(t, err)
 		shouldContinue, numberOfMessage := true, 0
 		go func() {
@@ -65,11 +66,11 @@ func TestNew(t *testing.T) {
 				}
 			}
 		}()
-		err = p1.Produce(producer.KafkaMessage[MyMsg, string]{Body: MyMsg{Time: time.Now().Format(time.RFC3339Nano)}})
+		err = p1.Produce(context.Background(), MyMsg{Time: time.Now().Format(time.RFC3339Nano)})
 		assert.NoError(t, err)
-		err = p2.Produce(producer.KafkaMessage[MyMsg, string]{Body: MyMsg{Time: time.Now().Format(time.RFC3339Nano)}})
+		err = p2.Produce(context.Background(), MyMsg{Time: time.Now().Format(time.RFC3339Nano)})
 		assert.NoError(t, err)
-		err = p2.Produce(producer.KafkaMessage[MyMsg, string]{Body: MyMsg{Time: time.Now().Format(time.RFC3339Nano)}})
+		err = p2.Produce(context.Background(), MyMsg{Time: time.Now().Format(time.RFC3339Nano)})
 		assert.NoError(t, err)
 		p1.Flush()
 		p2.Flush()

--- a/v2/internal/kafkaheaders/get.go
+++ b/v2/internal/kafkaheaders/get.go
@@ -1,0 +1,17 @@
+package kafkaheaders
+
+import "github.com/confluentinc/confluent-kafka-go/kafka"
+
+func Get(header string, message *kafka.Message) *string {
+	for _, h := range message.Headers {
+		if h.Key != header {
+			continue
+		}
+		if h.Value == nil {
+			return nil
+		}
+		s := string(h.Value)
+		return &s
+	}
+	return nil
+}

--- a/v2/internal/kafkaheaders/get_test.go
+++ b/v2/internal/kafkaheaders/get_test.go
@@ -1,0 +1,22 @@
+package kafkaheaders_test
+
+import (
+	"testing"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/honestbank/kp/v2/internal/kafkaheaders"
+)
+
+func TestGet(t *testing.T) {
+	t.Run("returns nil when header is not found", func(t *testing.T) {
+		assert.Nil(t, kafkaheaders.Get("retry-count", &kafka.Message{}))
+	})
+	t.Run("returns nil if the header value is nil", func(t *testing.T) {
+		assert.Nil(t, kafkaheaders.Get("retry-count", &kafka.Message{Headers: []kafka.Header{{"something", []byte("s")}, {"retry-count", nil}}}))
+	})
+	t.Run("returns value if the header value is nil", func(t *testing.T) {
+		assert.Equal(t, "count", *kafkaheaders.Get("retry-count", &kafka.Message{Headers: []kafka.Header{{"something", []byte("s")}, {"retry-count", []byte("count")}}}))
+	})
+}

--- a/v2/internal/kafkaheaders/set.go
+++ b/v2/internal/kafkaheaders/set.go
@@ -1,0 +1,14 @@
+package kafkaheaders
+
+import "github.com/confluentinc/confluent-kafka-go/kafka"
+
+func Set(message *kafka.Message, header string, value string) {
+	for i, h := range message.Headers {
+		if h.Key != header {
+			continue
+		}
+		message.Headers[i] = kafka.Header{Key: header, Value: []byte(value)}
+		return
+	}
+	message.Headers = append(message.Headers, kafka.Header{Key: header, Value: []byte(value)})
+}

--- a/v2/internal/kafkaheaders/set_test.go
+++ b/v2/internal/kafkaheaders/set_test.go
@@ -1,0 +1,42 @@
+package kafkaheaders_test
+
+import (
+	"testing"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/honestbank/kp/v2/internal/kafkaheaders"
+)
+
+func TestSet(t *testing.T) {
+	t.Run("can set when there's no existing header", func(t *testing.T) {
+		msg := kafka.Message{}
+		kafkaheaders.Set(&msg, "key", "value")
+		assert.Equal(t, "value", *kafkaheaders.Get("key", &msg))
+	})
+	t.Run("can set multiple keys and overwrite existing header", func(t *testing.T) {
+		msg := kafka.Message{}
+		kafkaheaders.Set(&msg, "key", "value")
+		kafkaheaders.Set(&msg, "key2", "value2")
+		assert.Equal(t, "value", *kafkaheaders.Get("key", &msg))
+		assert.Equal(t, "value2", *kafkaheaders.Get("key2", &msg))
+		kafkaheaders.Set(&msg, "key", "new-value")
+		kafkaheaders.Set(&msg, "key2", "new-value2")
+		assert.Equal(t, "new-value", *kafkaheaders.Get("key", &msg))
+		assert.Equal(t, "new-value2", *kafkaheaders.Get("key2", &msg))
+	})
+	t.Run("can work with pre-existing header", func(t *testing.T) {
+		msg := kafka.Message{
+			Headers: []kafka.Header{{Key: "key", Value: []byte("value")}},
+		}
+		kafkaheaders.Set(&msg, "key", "value")
+		kafkaheaders.Set(&msg, "key2", "value2")
+		assert.Equal(t, "value", *kafkaheaders.Get("key", &msg))
+		assert.Equal(t, "value2", *kafkaheaders.Get("key2", &msg))
+		kafkaheaders.Set(&msg, "key", "new-value")
+		kafkaheaders.Set(&msg, "key2", "new-value2")
+		assert.Equal(t, "new-value", *kafkaheaders.Get("key", &msg))
+		assert.Equal(t, "new-value2", *kafkaheaders.Get("key2", &msg))
+	})
+}

--- a/v2/internal/retrycounter/counter.go
+++ b/v2/internal/retrycounter/counter.go
@@ -3,30 +3,25 @@ package retrycounter
 import (
 	"strconv"
 
+	"github.com/honestbank/kp/v2/internal/kafkaheaders"
+
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 )
 
 const retryCountHeader = "x-retry-count"
 
 func GetCount(message *kafka.Message) int {
-	for _, header := range message.Headers {
-		if header.Key == retryCountHeader {
-			count, err := strconv.Atoi(string(header.Value))
-			if err != nil {
-				return 0
-			}
-			return count
-		}
+	val := kafkaheaders.Get(retryCountHeader, message)
+	if val == nil {
+		return 0
 	}
-	return 0
+	count, err := strconv.Atoi(*val)
+	if err != nil {
+		return 0
+	}
+	return count
 }
 
 func SetCount(message *kafka.Message, count int) {
-	for i, header := range message.Headers {
-		if header.Key == retryCountHeader {
-			message.Headers[i] = kafka.Header{Key: retryCountHeader, Value: []byte(strconv.Itoa(count))}
-			return
-		}
-	}
-	message.Headers = append(message.Headers, kafka.Header{Key: retryCountHeader, Value: []byte(strconv.Itoa(count))})
+	kafkaheaders.Set(message, retryCountHeader, strconv.Itoa(count))
 }

--- a/v2/kp.go
+++ b/v2/kp.go
@@ -40,7 +40,7 @@ func (t *kp[MessageType]) WithDeadletterOrPanic(deadletterTopic string) KafkaPro
 
 func (t *kp[MessageType]) WithRetry(retryTopic string, retryCount int) (KafkaProcessor[MessageType], error) {
 	t.topics = append(t.topics, retryTopic)
-	p, err := producer.New[MessageType, int](retryTopic)
+	p, err := producer.New[MessageType](retryTopic)
 	if err != nil {
 		return t, err
 	}
@@ -64,7 +64,7 @@ func (t *kp[MessageType]) WithRetry(retryTopic string, retryCount int) (KafkaPro
 }
 
 func (t *kp[MessageType]) WithDeadletter(deadLetterTopic string) (KafkaProcessor[MessageType], error) {
-	p, err := producer.New[MessageType, int](deadLetterTopic)
+	p, err := producer.New[MessageType](deadLetterTopic)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/kp_example_test.go
+++ b/v2/kp_example_test.go
@@ -51,12 +51,12 @@ func setup() {
 	if err != nil {
 		panic(err)
 	}
-	p, err := producer.New[UserLoggedInEvent, int]("user-logged-in")
+	p, err := producer.New[UserLoggedInEvent]("user-logged-in")
 	if err != nil {
 		panic(err)
 	}
 	now := time.Now().Format(time.RFC3339Nano)
 	event := UserLoggedInEvent{UserID: "1", Timestamp: now}
-	p.Produce(producer.KafkaMessage[UserLoggedInEvent, int]{Body: event})
+	p.Produce(context.Background(), event)
 	p.Flush()
 }

--- a/v2/kp_test.go
+++ b/v2/kp_test.go
@@ -41,8 +41,8 @@ func TestKP(t *testing.T) {
 	_, err = c.CreateTopics(context.Background(), []kafka.TopicSpecification{{Topic: "kp-topic", ReplicationFactor: 1, NumPartitions: 1}, {Topic: "kp-topic-retry", ReplicationFactor: 1, NumPartitions: 1}, {Topic: "kp-topic-dlt", ReplicationFactor: 1, NumPartitions: 1}})
 	assert.NoError(t, err)
 
-	p, err := producer.New[MyType, string]("kp-topic")
-	p.Produce(producer.KafkaMessage[MyType, string]{Body: MyType{Username: "username1", Count: 1}})
+	p, err := producer.New[MyType]("kp-topic")
+	p.Produce(context.Background(), MyType{Username: "username1", Count: 1})
 	p.Flush()
 	assert.NoError(t, err)
 	kp := v2.New[MyType]("kp-topic", "integration-tests")

--- a/v2/producer/producer_benchmark_test.go
+++ b/v2/producer/producer_benchmark_test.go
@@ -3,6 +3,7 @@
 package producer_test
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -24,7 +25,7 @@ func BenchmarkProducer(b *testing.B) {
 	os.Setenv("KP_SCHEMA_REGISTRY_ENDPOINT", "http://localhost:8081")
 	defer os.Unsetenv("KP_SCHEMA_REGISTRY_ENDPOINT")
 
-	kp, err := producer.New[BenchmarkMessage, int]("topic-kp")
+	kp, err := producer.New[BenchmarkMessage]("topic-kp")
 	assert.NoError(b, err)
 	defer kp.Flush()
 
@@ -39,11 +40,9 @@ func BenchmarkProducer(b *testing.B) {
 
 	b.Run("kp producer", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			err := kp.Produce(producer.KafkaMessage[BenchmarkMessage, int]{
-				Body: BenchmarkMessage{
-					Body:  "hello-world",
-					Count: i,
-				},
+			err := kp.Produce(context.Background(), BenchmarkMessage{
+				Body:  "hello-world",
+				Count: i,
 			})
 			assert.NoError(b, err)
 		}

--- a/v2/producer/producer_integration_test_remote_test.go
+++ b/v2/producer/producer_integration_test_remote_test.go
@@ -3,6 +3,7 @@
 package producer_test
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -24,16 +25,14 @@ func TestNewCanConnectToLabEnvironment(t *testing.T) {
 		_ = os.Unsetenv("KP_SECURITY_PROTOCOL")
 	}()
 	t.Run("produce through kp", func(t *testing.T) {
-		kp, err := producer.New[BenchmarkMessage, int]("topic-kp")
+		kp, err := producer.New[BenchmarkMessage]("topic-kp")
 		assert.NoError(t, err)
 		defer kp.Flush()
 
 		for i := 0; i < 100; i++ {
-			err := kp.Produce(producer.KafkaMessage[BenchmarkMessage, int]{
-				Body: BenchmarkMessage{
-					Body:  "hello-world",
-					Count: i,
-				},
+			err := kp.Produce(context.Background(), BenchmarkMessage{
+				Body:  "hello-world",
+				Count: i,
 			})
 			assert.NoError(t, err)
 		}

--- a/v2/producer/types.go
+++ b/v2/producer/types.go
@@ -1,18 +1,13 @@
 package producer
 
-import "github.com/confluentinc/confluent-kafka-go/kafka"
+import (
+	"context"
 
-type Producer[BodyType any, KeyType KeyTypes] interface {
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+)
+
+type Producer[BodyType any] interface {
 	Flush() error
-	Produce(message KafkaMessage[BodyType, KeyType]) error
+	Produce(context context.Context, message BodyType) error
 	ProduceRaw(message *kafka.Message) error
-}
-
-type KafkaMessage[BodyType any, KeyType any] struct {
-	Body BodyType
-	Key  *KeyType
-}
-
-type KeyTypes interface {
-	int | int64 | string
 }


### PR DESCRIPTION
## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to
  the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* Refactor so that producer doesn't accept a key, if a use case arises to use a key, people will have to serialize the message and use ProduceRaw. From what I found out, you should really not use keys unless there is a specific use case where you want to control in which partition you want the message to end up.
* Add a kafkaheader utility package to set and get header values since the header is an array and not a map.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/kp/22)
<!-- Reviewable:end -->
