### PR TITLE
fix: send to deadletter from no-op retry logic

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
+      - run: cd docs
       - run: npm ci
       - run: git config user.name github-actions
       - run: git config user.email github-actions@github.com

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -37,7 +37,7 @@ const config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/honestbank/kp/tree/main/docs/',
+            'https://github.com/honestbank/kp/edit/main/docs/',
         },
         blog: false,
         theme: {


### PR DESCRIPTION
## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to
  the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description
This PR has 3 changes

* fix: allows to use deadletters without retries.
* fixes automatic deployment of docs from github workflow.
* updates edit url link so editing is a 1 click experience.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/kp/27)
<!-- Reviewable:end -->
