### PR TITLE
feat: Add support for message keys in typed producer

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,10 +43,10 @@ jobs:
         run: docker compose up -d
       - name: wait for kafka
         run: |
-          wget https://downloads.apache.org/kafka/3.4.1/kafka_2.12-3.4.1.tgz
-          tar -xzf kafka_2.12-3.4.1.tgz
-          ./kafka_2.12-3.4.1/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
-          ./kafka_2.12-3.4.1/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
+          wget https://downloads.apache.org/kafka/3.4.1/kafka_2.13-3.4.1.tgz
+          tar -xzf kafka_2.13-3.4.1.tgz
+          ./kafka_2.13-3.4.1/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
+          ./kafka_2.13-3.4.1/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
       - run: sleep 10
       - name: Test and generate code coverage
         run: go test -v -race --tags=integration_test -coverprofile=coverage.txt -covermode=atomic ./...
@@ -54,8 +54,8 @@ jobs:
       - run: docker compose -f ./v2/docker-compose.yaml up -d
       - name: wait for kafka
         run: |
-          ./kafka_2.12-3.4.1/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
-          ./kafka_2.12-3.4.1/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
+          ./kafka_2.13-3.4.1/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
+          ./kafka_2.13-3.4.1/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
       - run: sleep 10
       - run: cd v2 && go test -v --tags=integration_test -coverprofile=coverage.txt -covermode=atomic ./...
       - run: tail -n +2 v2/coverage.txt >> coverage.txt && rm v2/coverage.txt

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,10 +43,10 @@ jobs:
         run: docker compose up -d
       - name: wait for kafka
         run: |
-          wget https://downloads.apache.org/kafka/3.2.3/kafka_2.13-3.2.3.tgz
-          tar -xzf kafka_2.13-3.2.3.tgz
-          ./kafka_2.13-3.2.3/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
-          ./kafka_2.13-3.2.3/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
+          wget https://downloads.apache.org/kafka/3.4.1/kafka_2.12-3.4.1.tgz
+          tar -xzf kafka_2.12-3.4.1.tgz
+          ./kafka_2.12-3.4.1/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
+          ./kafka_2.12-3.4.1/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
       - run: sleep 10
       - name: Test and generate code coverage
         run: go test -v -race --tags=integration_test -coverprofile=coverage.txt -covermode=atomic ./...
@@ -54,8 +54,8 @@ jobs:
       - run: docker compose -f ./v2/docker-compose.yaml up -d
       - name: wait for kafka
         run: |
-          ./kafka_2.13-3.2.3/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
-          ./kafka_2.13-3.2.3/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
+          ./kafka_2.12-3.4.1/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
+          ./kafka_2.12-3.4.1/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
       - run: sleep 10
       - run: cd v2 && go test -v --tags=integration_test -coverprofile=coverage.txt -covermode=atomic ./...
       - run: tail -n +2 v2/coverage.txt >> coverage.txt && rm v2/coverage.txt

--- a/docker-compose.integration.yaml
+++ b/docker-compose.integration.yaml
@@ -17,7 +17,7 @@ services:
     networks:
       kafka:
   local-kafka1:
-    image: confluentinc/cp-kafka:5.5.5
+    image: confluentinc/cp-kafka:7.3.2
     hostname: local-kafka1
     container_name: local-kafka1
     restart: "always"
@@ -38,7 +38,7 @@ services:
     networks:
       kafka:
   local-kafka2:
-    image: confluentinc/cp-kafka:5.5.5
+    image: confluentinc/cp-kafka:7.3.2
     hostname: local-kafka2
     container_name: local-kafka2
     restart: "always"
@@ -59,7 +59,7 @@ services:
     networks:
       kafka:
   local-kafka3:
-    image: confluentinc/cp-kafka:5.5.5
+    image: confluentinc/cp-kafka:7.3.2
     hostname: local-kafka3
     container_name: local-kafka3
     restart: "always"

--- a/v2/middlewares/deadletter/deadletter_test.go
+++ b/v2/middlewares/deadletter/deadletter_test.go
@@ -26,6 +26,10 @@ func (r producerMock) Produce(context context.Context, message any) error {
 	return nil
 }
 
+func (r producerMock) ProduceWithKey(context context.Context, key []byte, message any) error {
+	return nil
+}
+
 func (r producerMock) ProduceRaw(message *kafka.Message) error {
 	return r.produceRaw(message)
 }

--- a/v2/middlewares/retry/retry_test.go
+++ b/v2/middlewares/retry/retry_test.go
@@ -25,6 +25,10 @@ func (r producerMock) Produce(context context.Context, message any) error {
 	return nil
 }
 
+func (r producerMock) ProduceWithKey(context context.Context, key []byte, message any) error {
+	return nil
+}
+
 func (r producerMock) ProduceRaw(message *kafka.Message) error {
 	return r.produceRaw(message)
 }

--- a/v2/producer/producer.go
+++ b/v2/producer/producer.go
@@ -37,12 +37,9 @@ func doProduce[BodyType any](ctx context.Context, p UntypedProducer, key []byte,
 	}
 
 	msg := &kafka.Message{
+		Key:            key,
 		TopicPartition: partition,
 		Value:          value,
-	}
-
-	if key != nil {
-		msg.Key = key
 	}
 
 	tracing.InjectTraceHeaders(ctx, msg)

--- a/v2/producer/producer_test.go
+++ b/v2/producer/producer_test.go
@@ -5,6 +5,7 @@ package producer_test
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"testing"
 
 	"github.com/honestbank/kp/v2/config"
@@ -105,6 +106,20 @@ func TestNew(t *testing.T) {
 
 		for i := 0; i < 25000; i++ {
 			err := kp.Produce(context.Background(), BenchmarkMessage{
+				Body:  "hello-world",
+				Count: i,
+			})
+			assert.NoError(t, err)
+		}
+	})
+	t.Run("produce through kp with keys", func(t *testing.T) {
+		kp, err := producer.New[BenchmarkMessage]("topic-kp", cfg)
+		assert.NoError(t, err)
+		defer kp.Flush()
+
+		for i := 0; i < 25000; i++ {
+			key := fmt.Sprintf("key-%d", i)
+			err := kp.ProduceWithKey(context.Background(), []byte(key), BenchmarkMessage{
 				Body:  "hello-world",
 				Count: i,
 			})

--- a/v2/producer/types.go
+++ b/v2/producer/types.go
@@ -9,6 +9,7 @@ import (
 type Producer[BodyType any] interface {
 	Flush() error
 	Produce(context context.Context, message BodyType) error
+	ProduceWithKey(context context.Context, key []byte, message BodyType) error
 	ProduceRaw(message *kafka.Message) error
 }
 


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.
-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to
  the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* The kafka [producer API](https://github.com/honestbank/kp/blob/main/v2/producer/producer.go#L20) does not support setting message keys
* In our kafka-infrastructure, by default the topics are set to compat on keys
* Having empty keys deletes the messages on the topic
* To solve this, we need to do one of the two:
  1. Change the topic compaction policy (to not delete, to not compact on message keys)
  2. Change the KP interface to produce the messages with keys
* We can go ahead with (2) because it also aligns with the organization wide convention of (1) topic deletion policy, (2) messages between acq, and mlops having their keys as application-status-ids

### AC

* Update the [producer interface](https://github.com/honestbank/kp/blob/main/v2/producer/producer.go#L20) to also accept the keys, and produce the messages with message keys

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/kp/88)
<!-- Reviewable:end -->
