### PR TITLE
feat: add metric for dlq middleware [spe-4141]

### DIFF
--- a/v2/middlewares/measurement/promauto/dlq_tracking_measurement.go
+++ b/v2/middlewares/measurement/promauto/dlq_tracking_measurement.go
@@ -1,0 +1,37 @@
+package promauto
+
+import (
+	"context"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/honestbank/kp/v2/internal/retrycounter"
+	"github.com/honestbank/kp/v2/middlewares"
+)
+
+var retryCountReachedDuration = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "kp_retry_count_reached_total",
+}, []string{"application_name", "topic"})
+
+type dlqTrackingMeasurementMiddleware struct {
+	applicationName string
+	topic           string
+	threshold       int
+}
+
+func (m dlqTrackingMeasurementMiddleware) Process(ctx context.Context, item *kafka.Message, next func(ctx context.Context, item *kafka.Message) error) error {
+	if retrycounter.GetCount(item) >= m.threshold {
+		retryCountReachedDuration.WithLabelValues(m.applicationName, m.topic).Inc()
+	}
+	return next(ctx, item)
+}
+
+func NewDLQTrackingMeasurementMiddleware(applicationName, topic string, threshold int) middlewares.KPMiddleware[*kafka.Message] {
+	return dlqTrackingMeasurementMiddleware{
+		applicationName: applicationName,
+		topic:           topic,
+		threshold:       threshold,
+	}
+}

--- a/v2/middlewares/measurement/promauto/dlq_tracking_measurement_test.go
+++ b/v2/middlewares/measurement/promauto/dlq_tracking_measurement_test.go
@@ -1,0 +1,50 @@
+package promauto_test
+
+import (
+	"context"
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/honestbank/kp/v2/internal/retrycounter"
+	"github.com/honestbank/kp/v2/middlewares/measurement/promauto"
+)
+
+func TestDLQTrackingMeasurementMiddleware(t *testing.T) {
+	t.Run("should not report metric if threshold not reached", func(t *testing.T) {
+		message := &kafka.Message{}
+		retrycounter.SetCount(message, 1)
+		_ = promauto.NewDLQTrackingMeasurementMiddleware("mock-app", "mock-topic", 3).Process(context.Background(), message, func(ctx context.Context, item *kafka.Message) error {
+			return nil
+		})
+		metrics, err := scrapeMetrics()
+		require.NoError(t, err)
+		assert.NotContains(t, metrics, `kp_retry_count_reached_total`)
+	})
+	t.Run("should not report metric if threshold not reached", func(t *testing.T) {
+		message := &kafka.Message{}
+		retrycounter.SetCount(message, 3)
+		_ = promauto.NewDLQTrackingMeasurementMiddleware("mock-app", "mock-topic", 3).Process(context.Background(), message, func(ctx context.Context, item *kafka.Message) error {
+			return nil
+		})
+		metrics, err := scrapeMetrics()
+		require.NoError(t, err)
+		assert.Contains(t, metrics, `kp_retry_count_reached_total{application_name="mock-app",topic="mock-topic"} 1`)
+	})
+}
+
+func scrapeMetrics() (string, error) {
+	recorder := httptest.NewRecorder()
+	promhttp.Handler().ServeHTTP(recorder, httptest.NewRequest("GET", "/metrics", nil))
+	body, err := io.ReadAll(recorder.Result().Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.
-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to
  the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* We want to have metric for DLQ middleware that show:
  * when message published to DLQ successfully
  * when middleware failed publish to DLQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/kp/98)
<!-- Reviewable:end -->
