### PR TITLE
feat: change the default consumer session timeout to 30 seconds

### DIFF
--- a/v2/config/config.go
+++ b/v2/config/config.go
@@ -28,7 +28,7 @@ func (s Kafka) WithDefaults() Kafka {
 		SecurityProtocol:         s.SecurityProtocol,
 		Username:                 s.Username,
 		Password:                 s.Password,
-		ConsumerSessionTimeoutMs: defaultIfNil(s.ConsumerSessionTimeoutMs, 6000),
+		ConsumerSessionTimeoutMs: defaultIfNil(s.ConsumerSessionTimeoutMs, 30000),
 		ConsumerAutoOffsetReset:  defaultIfNil(s.ConsumerAutoOffsetReset, "earliest"),
 		ClientID:                 defaultIfNil(s.ClientID, "rdkafka"),
 		Debug:                    s.Debug,


### PR DESCRIPTION
## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to
  the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* Currently, the default consumer session timeout is only 6 seconds, which can trigger a early rebalance if the message processing takes more than 6 seconds.
* confluent kafka recommends a good default of 30 seconds.
* This PR changes the default to 30 seconds.

closes #104

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/kp/105)
<!-- Reviewable:end -->
