### PR TITLE
feat: Enable customized operations on success/retry/deadletter [SPE-5311]

### DIFF
--- a/v2/middlewares/deadletter/deadletter.go
+++ b/v2/middlewares/deadletter/deadletter.go
@@ -9,11 +9,23 @@ import (
 	"github.com/honestbank/kp/v2/middlewares"
 )
 
+type Builder struct {
+	onSuccess    func()
+	onRetry      func(err error)
+	onDeadLetter func(err error)
+}
+
 type deadletter struct {
+	// required
 	producer        Producer
 	onProduceErrors func(err error)
 	threshold       int
+	// optional
+	onSuccess    func()
+	onRetry      func(err error)
+	onDeadLetter func(err error)
 }
+
 type Producer interface {
 	ProduceRaw(message *kafka.Message) error
 }
@@ -21,11 +33,14 @@ type Producer interface {
 func (r deadletter) Process(ctx context.Context, item *kafka.Message, next func(ctx context.Context, item *kafka.Message) error) error {
 	err := next(ctx, item)
 	if err == nil {
+		r.onSuccess()
 		return nil
 	}
 	if retrycounter.GetCount(item) < r.threshold {
+		r.onRetry(err)
 		return err
 	}
+	r.onDeadLetter(err)
 	err = r.producer.ProduceRaw(&kafka.Message{Value: item.Value, Key: item.Key, Headers: item.Headers, Timestamp: item.Timestamp, TimestampType: item.TimestampType, Opaque: item.Opaque})
 	if err != nil {
 		r.onProduceErrors(err)
@@ -35,5 +50,42 @@ func (r deadletter) Process(ctx context.Context, item *kafka.Message, next func(
 }
 
 func NewDeadletterMiddleware(producer Producer, threshold int, onProduceErrors func(error)) middlewares.KPMiddleware[*kafka.Message] {
-	return deadletter{onProduceErrors: onProduceErrors, producer: producer, threshold: threshold}
+	return NewBuilder().Build(producer, threshold, onProduceErrors)
+}
+
+func NewBuilder() *Builder {
+	return &Builder{
+		onSuccess:    func() {},
+		onRetry:      func(err error) {},
+		onDeadLetter: func(err error) {},
+	}
+}
+
+func (b *Builder) OnSuccess(f func()) *Builder {
+	b.onSuccess = f
+
+	return b
+}
+
+func (b *Builder) OnRetry(f func(err error)) *Builder {
+	b.onRetry = f
+
+	return b
+}
+
+func (b *Builder) OnDeadLetter(f func(err error)) *Builder {
+	b.onDeadLetter = f
+
+	return b
+}
+
+func (b *Builder) Build(producer Producer, threshold int, onProduceErrors func(error)) middlewares.KPMiddleware[*kafka.Message] {
+	return deadletter{
+		onProduceErrors: onProduceErrors,
+		producer:        producer,
+		threshold:       threshold,
+		onSuccess:       b.onSuccess,
+		onRetry:         b.onRetry,
+		onDeadLetter:    b.onDeadLetter,
+	}
 }


### PR DESCRIPTION


<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.
-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to
  the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

This PR enables the deadletter middleware to run customized operations on success/retry/deadletter.

Example usages:
1. log errors when a message enters deadletter queue
2. emit metrics to monitor the distribution of success/retry/deadletter
