### PR TITLE
feat: send close to group coordinator [SS-7396]

### DIFF
--- a/v2/consumer/consumer.go
+++ b/v2/consumer/consumer.go
@@ -7,11 +7,11 @@ import (
 )
 
 type consumer struct {
-	kakfaConsumer *kafka.Consumer
+	kafkaConsumer *kafka.Consumer
 }
 
 func (c consumer) GetMessage() *kafka.Message {
-	ev := c.kakfaConsumer.Poll(100) // kafka's example uses 100ms and I'm going with it for now
+	ev := c.kafkaConsumer.Poll(100) // kafka's example uses 100ms and I'm going with it for now
 	if ev == nil {
 		return nil
 	}
@@ -30,9 +30,17 @@ func getMessageOrNil(event kafka.Event) *kafka.Message {
 }
 
 func (c consumer) Commit(message *kafka.Message) error {
-	_, err := c.kakfaConsumer.CommitMessage(message)
+	_, err := c.kafkaConsumer.CommitMessage(message)
 
 	return err
+}
+
+// Close leaves the consumer group and releases the underlying librdkafka handle.
+// Leaving the group explicitly lets the broker rebalance immediately instead of
+// waiting for session.timeout.ms to expire. Call this only after the processing
+// loop has stopped polling (i.e. after MessageProcessor.Run has returned).
+func (c consumer) Close() error {
+	return c.kafkaConsumer.Close()
 }
 
 func New(topics []string, cfg config.Kafka) (Consumer, error) {
@@ -47,5 +55,5 @@ func New(topics []string, cfg config.Kafka) (Consumer, error) {
 		return nil, err
 	}
 
-	return consumer{kakfaConsumer: k}, nil
+	return consumer{kafkaConsumer: k}, nil
 }

--- a/v2/consumer/types.go
+++ b/v2/consumer/types.go
@@ -5,4 +5,5 @@ import "github.com/confluentinc/confluent-kafka-go/v2/kafka"
 type Consumer interface {
 	GetMessage() *kafka.Message
 	Commit(message *kafka.Message) error
+	Close() error
 }

--- a/v2/kp_example_test.go
+++ b/v2/kp_example_test.go
@@ -49,6 +49,9 @@ func ExampleNew() {
 	if err != nil {
 		panic(err)
 	}
+	// Close after Run returns so the consumer leaves the group immediately,
+	// letting the broker rebalance right away instead of waiting for session.timeout.ms.
+	defer kafkaConsumer.Close()
 	go func() {
 		time.Sleep(time.Second * 10)
 		processor.Stop()

--- a/v2/kp_test.go
+++ b/v2/kp_test.go
@@ -100,6 +100,7 @@ func TestKP(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
+	defer kafkaConsumer.Close()
 
 	go func() {
 		time.Sleep(time.Second * (retryCount / 2))

--- a/v2/middlewares/consumer/consumer_test.go
+++ b/v2/middlewares/consumer/consumer_test.go
@@ -29,14 +29,20 @@ func (m *mockConsumer) GetMessage() *kafka.Message {
 	if err != nil {
 		return nil
 	}
+
 	return &kafka.Message{
 		Value: encode,
 	}
 }
 
-func (m *mockConsumer) Commit(message *kafka.Message) error {
+func (m *mockConsumer) Commit(_ *kafka.Message) error {
 	return nil
 }
+
+func (m *mockConsumer) Close() error {
+	return nil
+}
+
 func TestConsumerMiddleware_Process(t *testing.T) {
 	t.Run("if the message is not nil, it doesn't call GetMessage", func(t *testing.T) {
 		c := &mockConsumer{}


### PR DESCRIPTION
Linear: https://linear.app/honestbank/issue/SS-7396

## Summary

kp v2 never closed the underlying Kafka consumer — `Stop()` only exits the `Run` loop, so pods terminated without sending LeaveGroup. The group coordinator then waited `session.timeout.ms` (default 30s) before declaring the member dead, stalling the pod's partitions on every HPA scale-in or rolling deploy.

## Changes

- `v2/consumer/types.go` — add `Close() error` to the `Consumer` interface
- `v2/consumer/consumer.go` — implement `Close()` via `kafka.Consumer.Close()` (sends LeaveGroup → broker rebalances immediately)
- `v2/middlewares/consumer/consumer_test.go` — update mock
- `v2/kp_example_test.go`, `v2/kp_test.go` — document the `defer kafkaConsumer.Close()` pattern

## Usage

```go
kafkaConsumer, err := consumer.New(topics, cfg.WithDefaults())
if err != nil { /* handle */ }
defer kafkaConsumer.Close() // runs after Run returns → clean group leave

processor.
    AddMiddleware(gracefulshutdown.NewSignalMiddleware[*kafka.Message](processor.Stop)).
    AddMiddleware(consumer.NewConsumerMiddleware(kafkaConsumer)).
    Run(handler)
```

Shutdown ordering: SIGTERM → `Stop()` → in-flight message finishes + commits → `Run()` returns → deferred `Close()` → LeaveGroup → immediate rebalance.

## Notes

- Call `Close()` only after `Run()` returns (`defer` right after constructing the consumer gives this ordering)
- Breaking for external implementations of the `Consumer` interface — they must add `Close()`
- Rebalance is still eager/stop-the-world; cooperative-sticky enablement is a separate follow-up PR