### PR TITLE
feat: enable KIP-848 consumer protocol [SS-7404]

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -69,7 +69,8 @@ Retry and dead-letter middlewares are available under `middlewares/retry` and `m
 | `SocketKeepaliveEnabled` | `socket.keepalive.enable` | `false` |
 | `ConnectionsMaxIdleTimeoutMs` | `connections.max.idle.ms` | `30000` |
 | `MaxPollIntervalMs` | `max.poll.interval.ms` | `30000` |
-| `PartitionAssignmentStrategy` | `partition.assignment.strategy` | unset → librdkafka default (`"range,roundrobin"`) |
+| `PartitionAssignmentStrategy` | `partition.assignment.strategy` | unset → librdkafka default (`"range,roundrobin"`). Ignored when `GroupProtocol` is `"consumer"`. |
+| `GroupProtocol` | `group.protocol` | unset → librdkafka default (`"classic"`). Set `"consumer"` for the KIP-848 protocol. |
 | `Debug` | `debug` | unset |
 
 Pointer fields left `nil` (and not covered by a `WithDefaults()` value above) are never set on the librdkafka config, so librdkafka's own defaults apply.
@@ -91,26 +92,25 @@ SIGTERM → Stop() → in-flight message finishes and commits
 
 On Kubernetes, set `terminationGracePeriodSeconds` greater than your worst-case single-message processing time.
 
-## Partition assignment / cooperative rebalancing
+## Rebalancing (classic vs. KIP-848 consumer protocol)
 
-By default (field unset) kp consumers use librdkafka's `range,roundrobin` — the **eager** protocol: on any rebalance (scale in/out, deploy), every consumer revokes all partitions and the whole group pauses until reassignment finishes.
+By default kp consumers use the **classic** rebalance protocol with librdkafka's `range,roundrobin` assignor — the **eager** protocol: on any rebalance (scale in/out, deploy), every consumer revokes all partitions and the whole group pauses until reassignment finishes.
 
-For workloads that scale often (e.g. HPA), opt into **cooperative** rebalancing, where only the partitions that actually move are paused:
+For workloads that scale often (e.g. HPA), use the **KIP-848 consumer protocol** (`group.protocol=consumer`). Assignment is server-driven and incremental — only the partitions that actually move are paused — and it migrates online with a single rolling deploy.
 
 ```go
-strategy := "cooperative-sticky"
+protocol := "consumer"
 cfg := config.Kafka{
-	BootstrapServers:            "...",
-	ConsumerGroupName:           "my-service",
-	PartitionAssignmentStrategy: &strategy,
+	BootstrapServers:  "...",
+	ConsumerGroupName: "my-service",
+	GroupProtocol:     &protocol,
 }
 ```
 
-### Migrating a live consumer group
+Requirements and notes:
 
-A group cannot mix eager and cooperative members — switching directly causes `Inconsistent group protocol` errors during a rolling deploy. Migrate with two deploys:
+- **Brokers must support KIP-848** — Apache Kafka 4.0+ or Confluent Cloud.
+- Under `group.protocol=consumer`, `session.timeout.ms`, `heartbeat.interval.ms` and `partition.assignment.strategy` are **server-managed**. kp automatically stops sending them (setting them client-side is a fatal librdkafka error), so `ConsumerSessionTimeoutMs` and `PartitionAssignmentStrategy` have no effect in this mode.
+- **Migration is online.** Roll out `group.protocol=consumer` in a single deploy; when the first new pod joins, the group coordinator converts the group automatically and interoperates with any classic members still draining. No two-step dance, no downtime. Rolling back (removing the field) reverts the group once the last consumer-protocol member leaves.
 
-1. Deploy with `"cooperative-sticky,range"` — the group keeps running eager, but every pod now also supports cooperative.
-2. Deploy with `"cooperative-sticky"` — the group flips to cooperative.
-
-Rolling back from cooperative to eager requires the same two steps in reverse.
+> **Do not use `partition.assignment.strategy` for cooperative rebalancing on this stack.** librdkafka rejects a mixed eager+cooperative assignor list (`cooperative-sticky,range`) at startup, and a classic group has no zero-downtime path from eager to cooperative-sticky. Use the KIP-848 consumer protocol instead. `PartitionAssignmentStrategy` remains only for selecting a single classic assignor (e.g. `roundrobin`).

--- a/v2/config/config.go
+++ b/v2/config/config.go
@@ -22,7 +22,8 @@ type Kafka struct {
 	ConnectionsMaxIdleTimeoutMs *int
 	MaxPollIntervalMs           *int
 	Debug                       *string
-	PartitionAssignmentStrategy *string // nil = "range,roundrobin" (librdkafka default)
+	PartitionAssignmentStrategy *string // nil = "range,roundrobin" (librdkafka default). Ignored when GroupProtocol == "consumer".
+	GroupProtocol               *string // nil = "classic" (librdkafka default). Set "consumer" for the KIP-848 protocol (requires Kafka 4.0+ brokers).
 }
 
 func (s Kafka) WithDefaults() Kafka {
@@ -41,6 +42,7 @@ func (s Kafka) WithDefaults() Kafka {
 		MaxPollIntervalMs:           defaultIfNil(s.MaxPollIntervalMs, 30000),           // Default for librdkafka
 		Debug:                       s.Debug,
 		PartitionAssignmentStrategy: s.PartitionAssignmentStrategy,
+		GroupProtocol:               s.GroupProtocol,
 	}
 }
 
@@ -80,8 +82,15 @@ func GetKafkaConsumerConfig(config Kafka) *kafka.ConfigMap {
 	cfg := GetKafkaConfig(config)
 	hydrateIfNotNil(cfg, "group.id", &config.ConsumerGroupName)
 	hydrateIfNotNil(cfg, "auto.offset.reset", config.ConsumerAutoOffsetReset)
-	hydrateIfNotNil(cfg, "session.timeout.ms", config.ConsumerSessionTimeoutMs)
-	hydrateIfNotNil(cfg, "partition.assignment.strategy", config.PartitionAssignmentStrategy)
+	hydrateIfNotNil(cfg, "group.protocol", config.GroupProtocol)
+
+	// session.timeout.ms and partition.assignment.strategy are client-side only under the
+	// classic protocol. Under the KIP-848 "consumer" protocol they are server-managed, and
+	// setting them client-side makes librdkafka raise a fatal config error.
+	if config.GroupProtocol == nil || *config.GroupProtocol != "consumer" {
+		hydrateIfNotNil(cfg, "session.timeout.ms", config.ConsumerSessionTimeoutMs)
+		hydrateIfNotNil(cfg, "partition.assignment.strategy", config.PartitionAssignmentStrategy)
+	}
 	hydrateIfNotNil(cfg, "debug", config.Debug)
 
 	return cfg

--- a/v2/config/config_test.go
+++ b/v2/config/config_test.go
@@ -22,6 +22,36 @@ func TestGetKafkaConfig(t *testing.T) {
 	assignmentStrategy, err := withDefaults.Get("partition.assignment.strategy", "")
 	assert.NoError(t, err)
 	assert.Equal(t, "", assignmentStrategy, "must stay unset so librdkafka's default applies")
+	sessionTimeout, err := withDefaults.Get("session.timeout.ms", 0)
+	assert.NoError(t, err)
+	assert.Equal(t, 30000, sessionTimeout, "classic protocol keeps the client-side default")
+	groupProtocol, err := withDefaults.Get("group.protocol", "")
+	assert.NoError(t, err)
+	assert.Equal(t, "", groupProtocol, "must stay unset so librdkafka defaults to the classic protocol")
+}
+
+func TestGetKafkaConsumerConfig_ConsumerProtocol(t *testing.T) {
+	protocol := "consumer"
+	strategy := "cooperative-sticky"
+	cfg := config.GetKafkaConsumerConfig(config.Kafka{
+		BootstrapServers:            "localhost",
+		ConsumerGroupName:           "cg",
+		GroupProtocol:               &protocol,
+		PartitionAssignmentStrategy: &strategy,
+	}.WithDefaults())
+
+	got, err := cfg.Get("group.protocol", "")
+	assert.NoError(t, err)
+	assert.Equal(t, "consumer", got)
+
+	// KIP-848: these are server-managed and must not be sent client-side, even though
+	// WithDefaults() populates a session timeout and the caller passed a strategy.
+	sessionTimeout, err := cfg.Get("session.timeout.ms", "unset")
+	assert.NoError(t, err)
+	assert.Equal(t, "unset", sessionTimeout, "must not be set under the consumer protocol")
+	assignmentStrategy, err := cfg.Get("partition.assignment.strategy", "unset")
+	assert.NoError(t, err)
+	assert.Equal(t, "unset", assignmentStrategy, "must not be set under the consumer protocol")
 }
 
 func TestGetKafkaConsumerConfig_PartitionAssignmentStrategy(t *testing.T) {


### PR DESCRIPTION
Linear: https://linear.app/honestbank/issue/SS-7404

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to
  the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

kp v2 never set `group.protocol`, so consumers ran the **classic eager** rebalance protocol. Every rebalance (HPA scale in/out, rolling deploy) made all consumers revoke all partitions and froze the whole group until reassignment finished.

Cooperative-sticky (PR #170) is **not a viable fix on this stack**: confluent-kafka-go/librdkafka rejects a mixed eager+cooperative assignor list (`cooperative-sticky,range`) at consumer init, and a classic group has no zero-downtime path from eager to cooperative-sticky. That approach and its README migration guide were invalid.

This PR opts into **KIP-848** instead — the server-driven consumer rebalance protocol — which rebalances incrementally and **migrates online in a single rolling deploy**.

No consumer logic changes: kp subscribes via `SubscribeTopics(topics, nil)` (no rebalance callback), so KIP-848 works transparently.

**Rollout**: brokers already support KIP-848 (Confluent Cloud). Each service opts in by setting `GroupProtocol: "consumer"` and doing one rolling deploy.
